### PR TITLE
Allow lower case "firefox" as class name

### DIFF
--- a/exwm-firefox-evil.el
+++ b/exwm-firefox-evil.el
@@ -33,7 +33,7 @@
 (require 'evil-core)
 (require 'exwm-firefox-core)
 
-(defvar exwm-firefox-evil-firefox-class-name '("Firefox" "Nightly" "Iceweasel" "Icecat")
+(defvar exwm-firefox-evil-firefox-class-name '("Firefox" "firefox" "Nightly" "Iceweasel" "Icecat")
   "The class name used for detecting if a firefox buffer is selected.")
 
 (defvar exwm-firefox-evil-insert-on-new-tab t


### PR DESCRIPTION
A recent update to Firefox changed the names of the windows to "firefox" (with a lowercase "f"), which broke `exwm-firefox-evil`, since it only has "Firefox" in its list of possible class names. This PR adds "firefox" to the list, which seems to fix the issue.